### PR TITLE
Changing the Registry key extraction from Windows nodes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.418</version>
+    <version>1.420</version>
   </parent>
-  
+
   <artifactId>cygpath</artifactId>
-  <version>1.6-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT-26.03.2019</version>
   <packaging>hpi</packaging>
   <name>Jenkins Cygpath plugin</name>
   <description>Performs path conversion with cygpath</description>
@@ -21,9 +21,9 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/cygpath-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/cygpath-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/cygpath-plugin</url>
+    <connection>scm:git:git://github.com/ushasm/cygpath-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:ushasm/cygpath-plugin.git</developerConnection>
+    <url>https://github.com/ushasm/cygpath-plugin</url>
   </scm>
 
     <repositories>
@@ -39,6 +39,4 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-</project>  
-  
-
+</project>


### PR DESCRIPTION
Following changes made :

- Changed plugins artifactory version from 1.418 to 1.420.

- Changed the RegistryKey extraction process to use "REG QUERY" as the previous way was not handling the exceptions properly.

-  Added logger to capture logs of plugin execution.